### PR TITLE
Fix historical analysis tab

### DIFF
--- a/pages/2_Historical_Analysis.py
+++ b/pages/2_Historical_Analysis.py
@@ -81,7 +81,10 @@ with st.sidebar:
         help="Aggregate data to reduce noise and identify trends"
     )
 
-# Apply filters
+# Initialize analysis_data to avoid reference errors later
+analysis_data = pd.DataFrame()
+
+# Apply filters only if parameters are selected
 if selected_params:
     analysis_data = filtered_data[['timestamp'] + selected_params].copy()
     


### PR DESCRIPTION
Initialize `analysis_data` to prevent `NameError` when no parameters are selected in the Historical Analysis tab.

The `NameError` occurred because `analysis_data` was only defined inside an `if selected_params:` block. If `selected_params` was empty, `analysis_data` was never created, leading to a reference error when the page tried to use it later. Initializing it ensures the variable always exists.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff9f6cc0-b96c-49c8-9d24-ca01c253977c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ff9f6cc0-b96c-49c8-9d24-ca01c253977c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

